### PR TITLE
Add SanDisk mounting guide

### DIFF
--- a/docs/Misc/SanDisk_Not_Mounting.md
+++ b/docs/Misc/SanDisk_Not_Mounting.md
@@ -1,0 +1,30 @@
+# SanDisk Not Mounting Fix
+
+## Why it happens
+
+ExFAT sets a "dirty bit" in the volume header when mounted. On clean eject, it clears the bit. If you unplug without ejecting, the bit stays set. macOS sees the dirty bit on next plug-in and refuses to auto-mount to protect against potential corruption.
+
+## Steps when it happens
+
+Plug in the drive, then run the following commands in Terminal:
+
+```bash
+# 1. Find the drive
+diskutil list
+
+# 2. Try mounting
+diskutil mount disk4s2
+
+# 3. If that fails, mount read-only
+diskutil mount readOnly disk4s2
+
+# 4. If read-only works but you need write access, repair first
+sudo fsck_exfat -d disk4s2
+diskutil mount disk4s2
+```
+
+Replace `disk4s2` with whatever identifier shows up in step 1.
+
+## Prevention
+
+Always eject before unplugging: right-click → Eject in Finder, or `diskutil eject disk4`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -514,6 +514,7 @@ nav:
       - VMware Free: 'Misc/2_InstallVMWareFree.md'
       - VS Code Tips: 'Misc/4_VSTrics.md'
       - Background Apps: 'Misc/6_RunningAppsInBg.md'
+      - SanDisk Not Mounting Fix: 'Misc/SanDisk_Not_Mounting.md'
     - Data:
       - Datasets: 'Misc/5_WhichDatastsToUse.md'
       - Fact vs Dimension: 'Misc/10_Fact_vs_Dimension_tables.md'


### PR DESCRIPTION
## What changed

- Added the SanDisk not-mounting troubleshooting guide.
- Added it to Miscellaneous > System navigation.

## Why

Markdown files are not visible in this MkDocs site until they are included in `mkdocs.yml`.

## Validation

- Local page returned HTTP 200 and rendered correctly at `/home/Misc/SanDisk_Not_Mounting.html`.
- `mkdocs build --strict` was attempted, but repository-wide validation is blocked by 242 pre-existing broken-link warnings in unrelated pages. The new page produced no warning.
